### PR TITLE
Remove Trailing param

### DIFF
--- a/irc/conn.go
+++ b/irc/conn.go
@@ -179,7 +179,7 @@ func (c *Client) recv() {
 
 		switch msg.Command {
 		case Ping:
-			go c.write("PONG :" + msg.Trailing)
+			go c.write("PONG :" + msg.Params[len(msg.Params)-1])
 
 		case Join:
 			if msg.Nick == c.GetNick() {

--- a/irc/message.go
+++ b/irc/message.go
@@ -5,11 +5,10 @@ import (
 )
 
 type Message struct {
-	Prefix   string
-	Nick     string
-	Command  string
-	Params   []string
-	Trailing string
+	Prefix  string
+	Nick    string
+	Command string
+	Params  []string
 }
 
 func parseMessage(line string) *Message {
@@ -31,9 +30,13 @@ func parseMessage(line string) *Message {
 		}
 	}
 
+	var usesTrailing bool
+	var trailing string
+
 	if i := strings.Index(line, " :"); i > 0 {
 		cmdEnd = i
-		msg.Trailing = line[i+2:]
+		trailing = line[i+2:]
+		usesTrailing = true
 	}
 
 	cmd := strings.Split(line[cmdStart:cmdEnd], " ")
@@ -42,8 +45,8 @@ func parseMessage(line string) *Message {
 		msg.Params = cmd[1:]
 	}
 
-	if msg.Trailing != "" {
-		msg.Params = append(msg.Params, msg.Trailing)
+	if usesTrailing {
+		msg.Params = append(msg.Params, trailing)
 	}
 
 	return &msg

--- a/irc/message_test.go
+++ b/irc/message_test.go
@@ -14,11 +14,10 @@ func TestParseMessage(t *testing.T) {
 		{
 			":user CMD #chan :some message\r\n",
 			&Message{
-				Prefix:   "user",
-				Nick:     "user",
-				Command:  "CMD",
-				Params:   []string{"#chan", "some message"},
-				Trailing: "some message",
+				Prefix:  "user",
+				Nick:    "user",
+				Command: "CMD",
+				Params:  []string{"#chan", "some message"},
 			},
 		}, {
 			":nick!user@host.com CMD a b\r\n",
@@ -32,7 +31,7 @@ func TestParseMessage(t *testing.T) {
 			"CMD a b :\r\n",
 			&Message{
 				Command: "CMD",
-				Params:  []string{"a", "b"},
+				Params:  []string{"a", "b", ""},
 			},
 		}, {
 			"CMD a b\r\n",
@@ -48,9 +47,8 @@ func TestParseMessage(t *testing.T) {
 		}, {
 			"CMD :tests and stuff\r\n",
 			&Message{
-				Command:  "CMD",
-				Params:   []string{"tests and stuff"},
-				Trailing: "tests and stuff",
+				Command: "CMD",
+				Params:  []string{"tests and stuff"},
 			},
 		}, {
 			":nick@host.com CMD\r\n",

--- a/server/irc_handler.go
+++ b/server/irc_handler.go
@@ -59,11 +59,11 @@ func (i *ircHandler) nick(msg *irc.Message) {
 	i.session.sendJSON("nick", Nick{
 		Server:   i.client.Host,
 		Old:      msg.Nick,
-		New:      msg.Trailing,
+		New:      msg.Params[len(msg.Params)-1],
 		Channels: channelStore.FindUserChannels(msg.Nick, i.client.Host),
 	})
 
-	channelStore.RenameUser(msg.Nick, msg.Trailing, i.client.Host)
+	channelStore.RenameUser(msg.Nick, msg.Params[len(msg.Params)-1], i.client.Host)
 }
 
 func (i *ircHandler) join(msg *irc.Message) {
@@ -84,13 +84,20 @@ func (i *ircHandler) join(msg *irc.Message) {
 }
 
 func (i *ircHandler) part(msg *irc.Message) {
+	var chans []string
+	for i, param := range msg.Params {
+		if i != len(msg.Params)-1 {
+			chans = append(chans, param)
+		}
+	}
+
 	i.session.sendJSON("part", Part{
 		Join: Join{
 			Server:   i.client.Host,
 			User:     msg.Nick,
-			Channels: msg.Params,
+			Channels: chans,
 		},
-		Reason: msg.Trailing,
+		Reason: msg.Params[len(msg.Params)-1],
 	})
 
 	channelStore.RemoveUser(msg.Nick, i.client.Host, msg.Params[0])
@@ -118,7 +125,7 @@ func (i *ircHandler) message(msg *irc.Message) {
 	message := Chat{
 		Server:  i.client.Host,
 		From:    msg.Nick,
-		Message: msg.Trailing,
+		Message: msg.Params[len(msg.Params)-1],
 	}
 
 	if msg.Params[0] == i.client.GetNick() {
@@ -129,7 +136,7 @@ func (i *ircHandler) message(msg *irc.Message) {
 	}
 
 	if msg.Params[0] != "*" {
-		go i.session.user.LogMessage(i.client.Host, msg.Nick, msg.Params[0], msg.Trailing)
+		go i.session.user.LogMessage(i.client.Host, msg.Nick, msg.Params[0], msg.Params[len(msg.Params)-1])
 	}
 }
 
@@ -137,7 +144,7 @@ func (i *ircHandler) quit(msg *irc.Message) {
 	i.session.sendJSON("quit", Quit{
 		Server:   i.client.Host,
 		User:     msg.Nick,
-		Reason:   msg.Trailing,
+		Reason:   msg.Params[len(msg.Params)-1],
 		Channels: channelStore.FindUserChannels(msg.Nick, i.client.Host),
 	})
 
@@ -164,7 +171,7 @@ func (i *ircHandler) whoisServer(msg *irc.Message) {
 }
 
 func (i *ircHandler) whoisChannels(msg *irc.Message) {
-	i.whois.Channels = append(i.whois.Channels, strings.Split(strings.TrimRight(msg.Trailing, " "), " ")...)
+	i.whois.Channels = append(i.whois.Channels, strings.Split(strings.TrimRight(msg.Params[len(msg.Params)-1], " "), " ")...)
 }
 
 func (i *ircHandler) whoisEnd(msg *irc.Message) {
@@ -176,14 +183,14 @@ func (i *ircHandler) topic(msg *irc.Message) {
 	i.session.sendJSON("topic", Topic{
 		Server:  i.client.Host,
 		Channel: msg.Params[1],
-		Topic:   msg.Trailing,
+		Topic:   msg.Params[len(msg.Params)-1],
 	})
 
-	channelStore.SetTopic(msg.Trailing, i.client.Host, msg.Params[1])
+	channelStore.SetTopic(msg.Params[len(msg.Params)-1], i.client.Host, msg.Params[1])
 }
 
 func (i *ircHandler) names(msg *irc.Message) {
-	users := strings.Split(strings.TrimSuffix(msg.Trailing, " "), " ")
+	users := strings.Split(strings.TrimSuffix(msg.Params[len(msg.Params)-1], " "), " ")
 	userBuffer := i.userBuffers[msg.Params[2]]
 	i.userBuffers[msg.Params[2]] = append(userBuffer, users...)
 }
@@ -204,11 +211,11 @@ func (i *ircHandler) namesEnd(msg *irc.Message) {
 
 func (i *ircHandler) motdStart(msg *irc.Message) {
 	i.motdBuffer.Server = i.client.Host
-	i.motdBuffer.Title = msg.Trailing
+	i.motdBuffer.Title = msg.Params[len(msg.Params)-1]
 }
 
 func (i *ircHandler) motd(msg *irc.Message) {
-	i.motdBuffer.Content = append(i.motdBuffer.Content, msg.Trailing)
+	i.motdBuffer.Content = append(i.motdBuffer.Content, msg.Params[len(msg.Params)-1])
 }
 
 func (i *ircHandler) motdEnd(msg *irc.Message) {
@@ -270,5 +277,5 @@ func isChannel(s string) bool {
 }
 
 func printMessage(msg *irc.Message, i *irc.Client) {
-	log.Println(i.GetNick()+":", msg.Prefix, msg.Command, msg.Params, msg.Trailing)
+	log.Println(i.GetNick()+":", msg.Prefix, msg.Command, msg.Params, msg.Params[len(msg.Params)-1])
 }

--- a/server/irc_handler_test.go
+++ b/server/irc_handler_test.go
@@ -51,9 +51,9 @@ func checkResponse(t *testing.T, expectedType string, expectedData interface{}, 
 
 func TestHandleIRCNick(t *testing.T) {
 	res := dispatchMessage(&irc.Message{
-		Command:  irc.Nick,
-		Nick:     "old",
-		Trailing: "new",
+		Command: irc.Nick,
+		Nick:    "old",
+		Params:  []string{"new"},
 	})
 
 	checkResponse(t, "nick", Nick{
@@ -79,10 +79,9 @@ func TestHandleIRCJoin(t *testing.T) {
 
 func TestHandleIRCPart(t *testing.T) {
 	res := dispatchMessage(&irc.Message{
-		Command:  irc.Part,
-		Nick:     "parting",
-		Params:   []string{"#chan"},
-		Trailing: "the reason",
+		Command: irc.Part,
+		Nick:    "parting",
+		Params:  []string{"#chan", "the reason"},
 	})
 
 	checkResponse(t, "part", Part{
@@ -112,10 +111,9 @@ func TestHandleIRCMode(t *testing.T) {
 
 func TestHandleIRCMessage(t *testing.T) {
 	res := dispatchMessage(&irc.Message{
-		Command:  irc.Privmsg,
-		Nick:     "nick",
-		Params:   []string{"#chan"},
-		Trailing: "the message",
+		Command: irc.Privmsg,
+		Nick:    "nick",
+		Params:  []string{"#chan", "the message"},
 	})
 
 	checkResponse(t, "message", Chat{
@@ -126,10 +124,9 @@ func TestHandleIRCMessage(t *testing.T) {
 	}, res)
 
 	res = dispatchMessage(&irc.Message{
-		Command:  irc.Privmsg,
-		Nick:     "someone",
-		Params:   []string{"nick"},
-		Trailing: "the message",
+		Command: irc.Privmsg,
+		Nick:    "someone",
+		Params:  []string{"nick", "the message"},
 	})
 
 	checkResponse(t, "pm", Chat{
@@ -141,9 +138,9 @@ func TestHandleIRCMessage(t *testing.T) {
 
 func TestHandleIRCQuit(t *testing.T) {
 	res := dispatchMessage(&irc.Message{
-		Command:  irc.Quit,
-		Nick:     "nick",
-		Trailing: "the reason",
+		Command: irc.Quit,
+		Nick:    "nick",
+		Params:  []string{"the reason"},
 	})
 
 	checkResponse(t, "quit", Quit{
@@ -182,8 +179,8 @@ func TestHandleIRCWhois(t *testing.T) {
 		Params:  []string{"", "", "srv.com"},
 	})
 	i.dispatchMessage(&irc.Message{
-		Command:  irc.ReplyWhoisChannels,
-		Trailing: "#chan #chan1",
+		Command: irc.ReplyWhoisChannels,
+		Params:  []string{"#chan #chan1"},
 	})
 	i.dispatchMessage(&irc.Message{Command: irc.ReplyEndOfWhois})
 
@@ -199,9 +196,8 @@ func TestHandleIRCWhois(t *testing.T) {
 
 func TestHandleIRCTopic(t *testing.T) {
 	res := dispatchMessage(&irc.Message{
-		Command:  irc.ReplyTopic,
-		Params:   []string{"target", "#chan"},
-		Trailing: "the topic",
+		Command: irc.ReplyTopic,
+		Params:  []string{"target", "#chan", "the topic"},
 	})
 
 	checkResponse(t, "topic", Topic{
@@ -218,14 +214,12 @@ func TestHandleIRCNames(t *testing.T) {
 	i := newIRCHandler(c, s)
 
 	i.dispatchMessage(&irc.Message{
-		Command:  irc.ReplyNamReply,
-		Params:   []string{"", "", "#chan"},
-		Trailing: "a b c",
+		Command: irc.ReplyNamReply,
+		Params:  []string{"", "", "#chan", "a b c"},
 	})
 	i.dispatchMessage(&irc.Message{
-		Command:  irc.ReplyNamReply,
-		Params:   []string{"", "", "#chan"},
-		Trailing: "d",
+		Command: irc.ReplyNamReply,
+		Params:  []string{"", "", "#chan", "d"},
 	})
 	i.dispatchMessage(&irc.Message{
 		Command: irc.ReplyEndOfNames,
@@ -246,16 +240,16 @@ func TestHandleIRCMotd(t *testing.T) {
 	i := newIRCHandler(c, s)
 
 	i.dispatchMessage(&irc.Message{
-		Command:  irc.ReplyMotdStart,
-		Trailing: "motd title",
+		Command: irc.ReplyMotdStart,
+		Params:  []string{"motd title"},
 	})
 	i.dispatchMessage(&irc.Message{
-		Command:  irc.ReplyMotd,
-		Trailing: "line 1",
+		Command: irc.ReplyMotd,
+		Params:  []string{"line 1"},
 	})
 	i.dispatchMessage(&irc.Message{
-		Command:  irc.ReplyMotd,
-		Trailing: "line 2",
+		Command: irc.ReplyMotd,
+		Params:  []string{"line 2"},
 	})
 	i.dispatchMessage(&irc.Message{Command: irc.ReplyEndOfMotd})
 


### PR DESCRIPTION
Trailing itself shouldn't be exposed as separate from the parameters. This is because the trailing param is just a syntax hack to let the last parameter contain spaces.

As an example, these two lines are functionally identical in the IRC protocol, and both forms can be emitted by servers:
```
TOPIC #testchan cooltopic
TOPIC #testchan :cooltopic
```

In the first line, `cooltopic` is not trailing (since it doesn't need to be), and in the second one `cooltopic` is trailing. In this case, Dispatch currently fails to correctly display this. It also does the same on this for Privmsgs and such.

-------

If using the `msg.Params[len(msg.Params)-1]` syntax everywhere is ugly we could always replace it with something like `msg.LastParam` and make sure that the last parameter is always copied into it, but I'm iffy on that since it's duplicating info.