### PR TITLE
Improved Dockerfile to properly build and ship a runtime image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build
 release
+dispatch
 client/dist
 client/node_modules
 client/yarn-error.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,22 @@
-FROM scratch
+# Build
+FROM golang:alpine AS build
 
-ADD build/dispatch /
-ADD ca-certificates.crt /etc/ssl/certs/
+RUN apk add --update git make build-base && \
+    rm -rf /var/cache/apk/*
+
+WORKDIR /go/src/github.com/khlieng/dispatch
+COPY . /go/src/github.com/khlieng/dispatch
+RUN go build .
+
+# Runtime
+FROM alpine
+
+RUN apk add --update ca-certificates && \
+    rm -rf /var/cache/apk/*
+
+COPY --from=build /go/src/github.com/khlieng/dispatch/dispatch /dispatch
+
+EXPOSE 80/tcp
 
 VOLUME ["/data"]
 


### PR DESCRIPTION
See #11 -- Once this lands; we can redo the Docker Hub repo to build
from here automatically.