### PR TITLE
Fixes a case where a null `username` sends `USER  * 0:` to servers

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -40,6 +40,10 @@ type Client struct {
 }
 
 func NewClient(nick, username string) *Client {
+	if username == "" {
+		username = nick
+	}
+
 	return &Client{
 		nick:              nick,
 		Support:           newISupport(),


### PR DESCRIPTION
This causes (*arguably some less tolerant or buggy servers*) to ignore the
`USER` command from the client. [eris](https://github.com/prologic/eris) for
example.

This fixes that by defaulting to the `nick`.

Tested locally.