### PR TITLE
Makes configuration options consistent

### DIFF
--- a/server/irc.go
+++ b/server/irc.go
@@ -65,7 +65,7 @@ func connectIRC(server storage.Server, session *Session) *irc.Client {
 
 	if server.Password == "" &&
 		viper.GetString("defaults.password") != "" &&
-		address == viper.GetString("defaults.address") {
+		address == viper.GetString("defaults.host") {
 		i.Password = viper.GetString("defaults.password")
 	} else {
 		i.Password = server.Password


### PR DESCRIPTION
I noticed this while testing some things. `host` is used everywhere else
but this one place in code references `defaults.address`. It got confusing
and I'm not sure how things worked properly :/

Tested locally.