### PR TITLE
Allow dispatch to store data and configuration separately

### DIFF
--- a/commands/clear.go
+++ b/commands/clear.go
@@ -13,14 +13,14 @@ var clearCmd = &cobra.Command{
 	Use:   "clear",
 	Short: "Clear all user data",
 	Run: func(cmd *cobra.Command, args []string) {
-		err := os.Remove(storage.Path.Database())
+		err := os.Remove(storage.DataPath.Database())
 		if err == nil || os.IsNotExist(err) {
 			log.Println("Database cleared")
 		} else {
 			log.Println(err)
 		}
 
-		err = os.RemoveAll(storage.Path.Users())
+		err = os.RemoveAll(storage.DataPath.Users())
 		if err == nil {
 			log.Println("User data cleared")
 		} else {

--- a/commands/config.go
+++ b/commands/config.go
@@ -16,7 +16,7 @@ var (
 		Short: "Edit config file",
 		Run: func(cmd *cobra.Command, args []string) {
 			if editor := findEditor(); editor != "" {
-				process := exec.Command(editor, storage.Path.Config())
+				process := exec.Command(editor, storage.ConfigPath.Config())
 				process.Stdin = os.Stdin
 				process.Stdout = os.Stdout
 				process.Stderr = os.Stderr

--- a/config/config.go
+++ b/config/config.go
@@ -3,8 +3,8 @@ package config
 import (
 	"time"
 
-	"github.com/fsnotify/fsnotify"
 	"github.com/khlieng/dispatch/storage"
+	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/viper"
 )
 
@@ -53,7 +53,7 @@ type LetsEncrypt struct {
 
 func LoadConfig() (*Config, chan *Config) {
 	viper.SetConfigName("config")
-	viper.AddConfigPath(storage.Path.Root())
+	viper.AddConfigPath(storage.ConfigPath.Root())
 	viper.ReadInConfig()
 
 	config := &Config{}

--- a/server/server.go
+++ b/server/server.go
@@ -147,7 +147,7 @@ func (d *Dispatch) startHTTP() {
 		PortHTTPS: cfg.HTTPS.Port,
 		HTTPOnly:  !cfg.HTTPS.Enabled,
 
-		StoragePath: storage.Path.LetsEncrypt(),
+		StoragePath: storage.ConfigPath.LetsEncrypt(),
 		Domain:      cfg.LetsEncrypt.Domain,
 		Email:       cfg.LetsEncrypt.Email,
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -5,13 +5,22 @@ import (
 	"os"
 
 	"github.com/khlieng/dispatch/pkg/session"
+	"github.com/spf13/viper"
 )
 
-var Path directory
+var DataPath directory
+var ConfigPath directory
 
-func Initialize(dir string) {
-	Path = directory(dir)
-	os.MkdirAll(Path.Root(), 0700)
+func Initialize() {
+	if viper.GetString("dir") != DefaultDirectory() {
+		DataPath = directory(viper.GetString("dir"))
+		ConfigPath = directory(viper.GetString("dir"))
+	} else {
+		DataPath = directory(viper.GetString("data"))
+		ConfigPath = directory(viper.GetString("conf"))
+	}
+	os.MkdirAll(DataPath.Root(), 0700)
+	os.MkdirAll(ConfigPath.Root(), 0700)
 }
 
 var (

--- a/storage/user.go
+++ b/storage/user.go
@@ -32,7 +32,7 @@ func NewUser(store Store) (*User, error) {
 		return nil, err
 	}
 
-	err = os.MkdirAll(Path.User(user.Username), 0700)
+	err = os.MkdirAll(DataPath.User(user.Username), 0700)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func (u *User) Remove() {
 	if u.messageIndex != nil {
 		u.messageIndex.Close()
 	}
-	os.RemoveAll(Path.User(u.Username))
+	os.RemoveAll(DataPath.User(u.Username))
 }
 
 func (u *User) GetLastIP() []byte {

--- a/storage/user_cert.go
+++ b/storage/user_cert.go
@@ -28,12 +28,12 @@ func (u *User) SetCertificate(certPEM, keyPEM []byte) error {
 	u.certificate = &cert
 	u.lock.Unlock()
 
-	err = ioutil.WriteFile(Path.Certificate(u.Username), certPEM, 0600)
+	err = ioutil.WriteFile(ConfigPath.Certificate(u.Username), certPEM, 0600)
 	if err != nil {
 		return ErrCouldNotSaveCert
 	}
 
-	err = ioutil.WriteFile(Path.Key(u.Username), keyPEM, 0600)
+	err = ioutil.WriteFile(ConfigPath.Key(u.Username), keyPEM, 0600)
 	if err != nil {
 		return ErrCouldNotSaveCert
 	}
@@ -42,12 +42,12 @@ func (u *User) SetCertificate(certPEM, keyPEM []byte) error {
 }
 
 func (u *User) loadCertificate() error {
-	certPEM, err := ioutil.ReadFile(Path.Certificate(u.Username))
+	certPEM, err := ioutil.ReadFile(ConfigPath.Certificate(u.Username))
 	if err != nil {
 		return err
 	}
 
-	keyPEM, err := ioutil.ReadFile(Path.Key(u.Username))
+	keyPEM, err := ioutil.ReadFile(ConfigPath.Key(u.Username))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is an attempt to split the configuration storage from the data storage and to be able to specify where each should be put to.

I've removed the "--dir" flag in favor of "--data" and "--config". I guess it could be a good idea to keep "--dir" as compatibility, but that would lead to confusion. Maybe a warning or something ?