### PR TITLE
Replace Freenode with freenode

### DIFF
--- a/config.default.toml
+++ b/config.default.toml
@@ -7,7 +7,7 @@ verify_certificates = true
 
 # Defaults for the client connect form
 [defaults]
-name = "Freenode"
+name = "freenode"
 host = "chat.freenode.net"
 port = 6697
 channels = [

--- a/storage/user_test.go
+++ b/storage/user_test.go
@@ -28,7 +28,7 @@ func TestUser(t *testing.T) {
 	assert.Nil(t, err)
 
 	srv := &storage.Server{
-		Name: "Freenode",
+		Name: "freenode",
 		Host: "irc.freenode.net",
 		Nick: "test",
 	}


### PR DESCRIPTION
The freenode IRC network brands itself with a lowercase `f`. This can be seen on https://freenode.net/project and throughout the rest of the site.