### PR TITLE
I2p support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548 // indirect
 	github.com/cznic/strutil v0.0.0-20181122101858-275e90344537 // indirect
 	github.com/dsnet/compress v0.0.1
+	github.com/eyedeekay/goSam v0.32.22
+	github.com/eyedeekay/sam3 v0.32.3 // indirect
 	github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51 // indirect
 	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
 	github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870 // indirect

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,11 @@ github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFP
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/exoscale/egoscale v0.18.1/go.mod h1:Z7OOdzzTOz1Q1PjQXumlz9Wn/CddH0zSYdCF3rnBKXE=
+github.com/eyedeekay/goSam v0.32.22 h1:SD0GEQ8MGJ1wZ4MepSa0mpZjiZAGMSTUhSwAZVrm2kg=
+github.com/eyedeekay/goSam v0.32.22/go.mod h1:YIklxqKiJ3I5JNRgb5pM7VCQOSNDGnVulHnrKBbbECM=
+github.com/eyedeekay/ramp v0.0.0-20190429201811-305b382042ab/go.mod h1:h7mvUAMgZ/rtRDUOkvKTK+8LnDMeUhJSoa5EPdB51fc=
+github.com/eyedeekay/sam3 v0.32.2/go.mod h1:Y3igFVzN4ybqkkpfUWULGhw7WRp8lieq0ORXbLBbcZM=
+github.com/eyedeekay/sam3 v0.32.3/go.mod h1:qRA9KIIVxbrHlkj+ZB+OoxFGFgdKeGp1vSgPw26eOVU=
 github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51 h1:0JZ+dUmQeA8IIVUMzysrX4/AKuQwWhV2dYQuPZdvdSQ=
 github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51/go.mod h1:Yg+htXGokKKdzcwhuNDwVvN+uBxDGXJ7G/VN1d8fa64=
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 h1:JWuenKqqX8nojtoVVWjGfOF9635RETekkoH6Cc9SX0A=

--- a/server/irc.go
+++ b/server/irc.go
@@ -80,7 +80,7 @@ func connectIRC(network *storage.Network, state *State, srcIP []byte) *irc.Clien
 
 	if cfg.Proxy.Enabled && strings.ToLower(cfg.Proxy.Protocol) == "i2p" {
 		addr := net.JoinHostPort(cfg.Proxy.Host, cfg.Proxy.Port)
-		log.Println("USING I2P!")
+
 		client, err := goSam.NewClient(addr)
 		if err != nil {
 			log.Println(err)

--- a/server/irc.go
+++ b/server/irc.go
@@ -80,21 +80,12 @@ func connectIRC(network *storage.Network, state *State, srcIP []byte) *irc.Clien
 
 	if cfg.Proxy.Enabled && strings.ToLower(cfg.Proxy.Protocol) == "i2p" {
 		addr := net.JoinHostPort(cfg.Proxy.Host, cfg.Proxy.Port)
-
-		//var auth *proxy.Auth
-		//if cfg.Proxy.Username != "" {
-		//auth = &proxy.Auth{
-		//User:     cfg.Proxy.Username,
-		//Password: cfg.Proxy.Password,
-		//}
-		//}
-
-		//dialer, err := proxy.SOCKS5("tcp", addr, auth, irc.DefaultDialer)
+		log.Println("USING I2P!")
 		client, err := goSam.NewClient(addr)
 		if err != nil {
 			log.Println(err)
 		} else {
-			ircCfg.Dialer = client //.Dial
+			ircCfg.Dialer = client
 		}
 	}
 

--- a/server/irc.go
+++ b/server/irc.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"strings"
 
+	"github.com/eyedeekay/goSam"
 	"github.com/khlieng/dispatch/pkg/irc"
 	"github.com/khlieng/dispatch/storage"
 	"golang.org/x/net/proxy"
@@ -74,6 +75,26 @@ func connectIRC(network *storage.Network, state *State, srcIP []byte) *irc.Clien
 			log.Println(err)
 		} else {
 			ircCfg.Dialer = dialer
+		}
+	}
+
+	if cfg.Proxy.Enabled && strings.ToLower(cfg.Proxy.Protocol) == "i2p" {
+		addr := net.JoinHostPort(cfg.Proxy.Host, cfg.Proxy.Port)
+
+		//var auth *proxy.Auth
+		//if cfg.Proxy.Username != "" {
+		//auth = &proxy.Auth{
+		//User:     cfg.Proxy.Username,
+		//Password: cfg.Proxy.Password,
+		//}
+		//}
+
+		//dialer, err := proxy.SOCKS5("tcp", addr, auth, irc.DefaultDialer)
+		client, err := goSam.NewClient(addr)
+		if err != nil {
+			log.Println(err)
+		} else {
+			ircCfg.Dialer = client //.Dial
 		}
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -81,6 +81,11 @@ github.com/davecgh/go-spew/spew
 github.com/dsnet/compress/brotli
 github.com/dsnet/compress/internal
 github.com/dsnet/compress/internal/errors
+# github.com/eyedeekay/goSam v0.32.22
+## explicit
+github.com/eyedeekay/goSam
+# github.com/eyedeekay/sam3 v0.32.3
+## explicit
 # github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51
 ## explicit
 # github.com/facebookgo/stack v0.0.0-20160209184415-751773369052


### PR DESCRIPTION
Hello dispatch team! I was looking for a cool IRC client written in Go to demonstrate how easy it is to adapt applications to the I2P overlay network using our SAM client protocol. We're an anonymous overlay network, a little like Tor but with a specialized DHT instead of directories. This patch allows setting the "proxy" value to SAM and to use the proxy host and port settings as the SAM API address. It's a very simple, stable, backward-compatible API which does not necessarily require bundling an I2P router with the application in question, and done in this way should not increase the maintenance required in your application.