### PR TITLE
client: Downgraded @sindresorhus/fnv1a to v1.2.0 to fix #66

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -62,7 +62,7 @@
     "workbox-webpack-plugin": "^5.1.3"
   },
   "dependencies": {
-    "@sindresorhus/fnv1a": "^2.0.1",
+    "@sindresorhus/fnv1a": "^1.2.0",
     "autolinker": "^3.14.1",
     "backo": "^1.1.0",
     "classnames": "^2.2.6",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1804,9 +1804,10 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@sindresorhus/fnv1a@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/fnv1a/-/fnv1a-2.0.1.tgz#2aefdfa7eb5b7f29a7936978218e986c70c603fc"
+"@sindresorhus/fnv1a@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/fnv1a/-/fnv1a-1.2.0.tgz#d554da64c406f3b62ad06dfce9efd537a4a55de4"
+  integrity sha512-5ezb/dBSTWtKQ4sLQwMgOJyREXJcZZkTMbendMwKrXTghUhWjZhstzkkmt4/WkFy/GSTSGzfJOKU7dEXv3C/XQ==
 
 "@sinonjs/commons@^1.7.0":
   version "1.7.2"


### PR DESCRIPTION
Downgrading the JS package @sindresorhus/fnv1a to v1.2.0 indeed fixes #66 without negatively impacting the nickname coloring.
Can confirm dev builds are working in Safari 13 on macOS and iOS after this change.