### PR TITLE
Channels can also start with a &

### DIFF
--- a/client/js/commands.js
+++ b/client/js/commands.js
@@ -36,7 +36,7 @@ const findHelp = cmd =>
 export default createCommandMiddleware(COMMAND, {
   join({ dispatch, network }, channel) {
     if (channel) {
-      if (channel[0] !== '#') {
+      if (channel[0] !== '#' && channel[0] !== '&') {
         return error('Bad channel name');
       }
       dispatch(join([channel], network));

--- a/client/js/components/pages/Connect.js
+++ b/client/js/components/pages/Connect.js
@@ -22,7 +22,7 @@ const transformChannels = channels => {
     .map(channel => {
       channel = channel.trim();
       if (channel) {
-        if (isValidChannel(channel, false) && channel[0] !== '#') {
+        if (isValidChannel(channel, false) && channel[0] !== '#' && channel[0] !== '&') {
           channel = `#${channel}`;
         }
       }

--- a/client/js/state/channels.js
+++ b/client/js/state/channels.js
@@ -2,7 +2,7 @@ import { createSelector } from 'reselect';
 import get from 'lodash/get';
 import sortBy from 'lodash/sortBy';
 import createReducer from 'utils/createReducer';
-import { trimPrefixChar, find, findIndex } from 'utils';
+import { find, findIndex } from 'utils';
 import { getSelectedTab, updateSelection } from './tab';
 import * as actions from './actions';
 
@@ -101,7 +101,7 @@ export const getSortedChannels = createSelector(getChannels, channels =>
     Object.keys(channels).map(network => ({
       address: network,
       channels: sortBy(channels[network], channel =>
-        trimPrefixChar(channel.name, '#').toLowerCase()
+        channel.name.replace(/^[#&]*/, '').toLowerCase()
       )
     })),
     network => network.address.toLowerCase()

--- a/client/js/utils/__tests__/util.test.js
+++ b/client/js/utils/__tests__/util.test.js
@@ -1,5 +1,4 @@
 import {
-  trimPrefixChar,
   isChannel,
   isValidNick,
   isValidChannel,
@@ -7,22 +6,16 @@ import {
 } from '..';
 import linkify from '../linkify';
 
-describe('trimPrefixChar()', () => {
-  it('trims prefix characters', () => {
-    expect(trimPrefixChar('##chan', '#')).toBe('chan');
-    expect(trimPrefixChar('#chan', '#')).toBe('chan');
-    expect(trimPrefixChar('chan', '#')).toBe('chan');
-  });
-});
-
 describe('isChannel()', () => {
   it('it handles strings', () => {
     expect(isChannel('#cake')).toBe(true);
+    expect(isChannel('&snake')).toBe(true);
     expect(isChannel('cake')).toBe(false);
   });
 
   it('handles tab objects', () => {
     expect(isChannel({ name: '#cake' })).toBe(true);
+    expect(isChannel({ name: '&snake' })).toBe(true);
     expect(isChannel({ name: 'cake' })).toBe(false);
   });
 });
@@ -48,6 +41,7 @@ describe('isValidChannel()', () => {
   it('validates channels', () =>
     Object.entries({
       '#chan': true,
+      '&snake': true,
       '#cak e': false,
       '#cake:': false,
       '#[cake]': true,
@@ -64,6 +58,7 @@ describe('isValidChannel()', () => {
       chan: true,
       'cak e': false,
       '#cake:': false,
+      '&snake': true,
       '#[cake]': true,
       '#ca,ke': false
     }).forEach(([input, expected]) =>

--- a/client/js/utils/index.js
+++ b/client/js/utils/index.js
@@ -8,7 +8,7 @@ export function isChannel(name) {
   if (typeof name === 'object') {
     ({ name } = name);
   }
-  return typeof name === 'string' && name[0] === '#';
+  return typeof name === 'string' && (name[0] === '#' || name[0] === '&');
 }
 
 export function stringifyTab(network, name) {
@@ -36,22 +36,6 @@ function isString(s, maxLength) {
 
 export function isDM({ from, to }) {
   return !to && from?.indexOf('.') === -1 && !isChannel(from);
-}
-
-export function trimPrefixChar(str, char) {
-  if (!isString(str)) {
-    return str;
-  }
-
-  let start = 0;
-  while (str[start] === char) {
-    start++;
-  }
-
-  if (start > 0) {
-    return str.slice(start);
-  }
-  return str;
 }
 
 // RFC 2812
@@ -88,7 +72,7 @@ export function isValidChannel(channel, requirePrefix = true) {
     return false;
   }
 
-  if (requirePrefix && channel[0] !== '#') {
+  if (requirePrefix && channel[0] !== '#' && channel[0] !== '&' ) {
     return false;
   }
 


### PR DESCRIPTION
The & signifies server-local channels. https://irc.net uses Bitlbee which gives the user a command interface via just such a server-local channel.

Remove trimPrefixChar given that it is used in exactly one place and has a terse native replacement.